### PR TITLE
Multi-elevation & face normal placement

### DIFF
--- a/cabinets/cabinet_ops.py
+++ b/cabinets/cabinet_ops.py
@@ -1,7 +1,6 @@
 import bpy
 import os
 import math
-import time
 import inspect
 from ..pc_lib import pc_types, pc_unit, pc_utils
 from . import cabinet_library

--- a/cabinets/cabinet_ops.py
+++ b/cabinets/cabinet_ops.py
@@ -222,7 +222,7 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
                 self.cabinet.obj_bp.rotation_euler.z += math.radians(180)
             self.cabinet.obj_bp.location.x = mouse_location[0]
             self.cabinet.obj_bp.location.y = mouse_location[1]
-
+            self.cabinet.obj_bp.location.z = self.base_height + wall_bp.location.z
 
         else:
 
@@ -268,7 +268,6 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
         ## with each mouseMove event, maintains difference between lower and upper cabinets
         self.base_height = self.cabinet.obj_bp.location.z
         self.base_cabinet = self.cabinet
-
 
     def has_height_collision(self,assembly):
         cab1_z_1 = self.cabinet.obj_bp.matrix_world[2][3]
@@ -337,16 +336,13 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
 
             if self.selected_normal.y == 1:
                 self.cabinet.obj_bp.rotation_euler = (0, 0,math.radians(180))
-                self.cabinet.obj_bp.location = (0, self.current_wall.obj_y.location.y, self.cabinet.obj_bp.location.z - context.scene.cursor.location.z)
-
+                self.cabinet.obj_bp.location = (0, self.current_wall.obj_y.location.y, self.cabinet.obj_bp.location.z - self.current_wall.obj_bp.location.z)
             elif self.selected_cabinet:
                 self.cabinet.obj_bp.rotation_euler = self.selected_cabinet.obj_bp.rotation_euler
-                self.cabinet.obj_bp.location = (0, self.selected_cabinet.obj_bp.location.y, self.cabinet.obj_bp.location.z - context.scene.cursor.location.z)
-
+                self.cabinet.obj_bp.location = (0, self.selected_cabinet.obj_bp.location.y, self.cabinet.obj_bp.location.z - self.current_wall.obj_bp.location.z)
             else:
                 self.cabinet.obj_bp.rotation_euler = (0, 0, 0)
-                self.cabinet.obj_bp.location = (0, 0, self.cabinet.obj_bp.location.z - context.scene.cursor.location.z)
-
+                self.cabinet.obj_bp.location = (0, 0, self.cabinet.obj_bp.location.z - self.current_wall.obj_bp.location.z)
             self.cabinet.obj_bp.parent = self.current_wall.obj_bp
             self.cabinet.obj_bp.location.x = x_loc
 
@@ -361,7 +357,6 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
             constraint.use_z = False
 
         if self.placement == 'RIGHT':
-
             self.cabinet.obj_bp.parent = self.selected_cabinet.obj_bp.parent
             constraint_obj = self.selected_cabinet.obj_x
             constraint = self.cabinet.obj_bp.constraints.new('COPY_LOCATION')
@@ -531,7 +526,6 @@ class home_builder_OT_move_cabinet(bpy.types.Operator):
         self.exclude_objects = []
         self.class_name = ""
 
-    # def invoke(self,context,event):
     def execute(self, context):
         self.reset_properties()
         self.create_drawing_plane(context)

--- a/cabinets/cabinet_ops.py
+++ b/cabinets/cabinet_ops.py
@@ -209,7 +209,10 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
             self.cabinet.obj_bp.location.x = mouse_location[0]
             self.cabinet.obj_bp.location.y = mouse_location[1]
 
-            ## if selected object is vertical ie wall
+            ## if selected object is vertical ie wall 
+            ## or ray cast doesn't hit anything returning Vector(0,0,0) ie selected_object
+            ## is None and self.select_obj_unapplied_rot = 0
+            
             if selected_normal.z == 0:
                 self.rotate_to_normal(selected_normal)
                 self.cabinet.obj_bp.rotation_euler.z += self.select_obj_unapplied_rot

--- a/cabinets/cabinet_ops.py
+++ b/cabinets/cabinet_ops.py
@@ -346,10 +346,10 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
         self.refresh_data(False)
 
     def modal(self, context, event):
-        print(event)
+        
         bpy.ops.object.select_all(action='DESELECT')
 
-        context.area.tag_redraw()
+        context.view_layer.update()
         #EMPTY MUST BE VISIBLE TO CALCULATE CORRECT SIZE FOR HEIGHT COLLISION
         self.cabinet.obj_z.empty_display_size = .001
         self.cabinet.obj_z.hide_viewport = False

--- a/cabinets/cabinet_ops.py
+++ b/cabinets/cabinet_ops.py
@@ -128,8 +128,11 @@ class home_builder_OT_place_cabinet(bpy.types.Operator):
     def position_cabinet(self,mouse_location,selected_obj,event,cursor_z,selected_normal):
 
         ##get roatations from parent heirarchy
-        parented_rotation_sum = self.accumulate_z_rotation(selected_obj)
-        self.select_obj_unapplied_rot = selected_obj.rotation_euler.z + parented_rotation_sum
+        if selected_obj is not None:
+            parented_rotation_sum = self.accumulate_z_rotation(selected_obj)
+            self.select_obj_unapplied_rot = selected_obj.rotation_euler.z + parented_rotation_sum
+        else:
+            self.select_obj_unapplied_rot = 0
 
         self.selected_normal = selected_normal
         cabinet_bp = home_builder_utils.get_cabinet_bp(selected_obj)

--- a/doors_windows/door_window_ops.py
+++ b/doors_windows/door_window_ops.py
@@ -105,7 +105,7 @@ class home_builder_OT_place_door_window(bpy.types.Operator):
         self.mouse_x = event.mouse_x
         self.mouse_y = event.mouse_y
 
-        selected_point, selected_obj = pc_utils.get_selection_point(context,event,exclude_objects=self.exclude_objects)
+        selected_point, selected_obj, selected_normal = pc_utils.get_selection_point(context,event,exclude_objects=self.exclude_objects)
 
         self.position_object(selected_point,selected_obj)
 

--- a/pc_lib/pc_utils.py
+++ b/pc_lib/pc_utils.py
@@ -7,11 +7,14 @@ import math, random
 import bmesh
 import inspect
 
+
 def get_wm_props(window_manager):
     return window_manager.pyclone
 
+
 def get_scene_props(scene):
-    return scene.pyclone    
+    return scene.pyclone
+
 
 def get_object_icon(obj):
     ''' 
@@ -34,23 +37,24 @@ def get_object_icon(obj):
     if obj.type == 'LATTICE':
         return 'OUTLINER_OB_LATTICE'
     if obj.type == 'META':
-        return 'OUTLINER_OB_META'                                            
+        return 'OUTLINER_OB_META'
     if obj.type == 'LIGHT':
-        return 'OUTLINER_OB_LIGHT'    
+        return 'OUTLINER_OB_LIGHT'
     if obj.type == 'CAMERA':
-        return 'OUTLINER_OB_CAMERA'    
+        return 'OUTLINER_OB_CAMERA'
     if obj.type == 'SURFACE':
-        return 'OUTLINER_OB_SURFACE'    
+        return 'OUTLINER_OB_SURFACE'
     if obj.type == 'ARMATURE':
-        return 'OUTLINER_OB_ARMATURE'    
+        return 'OUTLINER_OB_ARMATURE'
     if obj.type == 'SPEAKER':
-        return 'OUTLINER_OB_SPEAKER'    
+        return 'OUTLINER_OB_SPEAKER'
     if obj.type == 'FORCE_FIELD':
-        return 'OUTLINER_OB_FORCE_FIELD'    
+        return 'OUTLINER_OB_FORCE_FIELD'
     if obj.type == 'GPENCIL':
-        return 'OUTLINER_OB_GREASEPENCIL'    
+        return 'OUTLINER_OB_GREASEPENCIL'
     if obj.type == 'LIGHT_PROBE':
-        return 'OUTLINER_OB_LIGHTPROBE'  
+        return 'OUTLINER_OB_LIGHTPROBE'
+
 
 def object_has_driver(obj):
     """ If the object has a driver this function will return True otherwise False
@@ -59,17 +63,19 @@ def object_has_driver(obj):
         if len(obj.animation_data.drivers) > 0:
             return True
 
+
 def get_assembly_bp(obj):
     if "IS_ASSEMBLY_BP" in obj:
         return obj
     elif obj.parent:
         return get_assembly_bp(obj.parent)
 
-def hook_vertex_group_to_object(obj_mesh,vertex_group,obj_hook):
+
+def hook_vertex_group_to_object(obj_mesh, vertex_group, obj_hook):
     """ This function adds a hook modifier to the verties 
         in the vertex_group to the obj_hook
     """
-    bpy.ops.object.select_all(action = 'DESELECT')
+    bpy.ops.object.select_all(action='DESELECT')
     obj_hook.hide_set(False)
     obj_hook.hide_viewport = False
     obj_hook.hide_select = False
@@ -81,14 +87,15 @@ def hook_vertex_group_to_object(obj_mesh,vertex_group,obj_hook):
         obj_mesh.vertex_groups.active_index = vgroup.index
         bpy.context.view_layer.objects.active = obj_mesh
         bpy.ops.pc_object.toggle_edit_mode(obj_name=obj_mesh.name)
-        bpy.ops.mesh.select_all(action = 'DESELECT')
+        bpy.ops.mesh.select_all(action='DESELECT')
         bpy.ops.object.vertex_group_select()
         if obj_mesh.data.total_vert_sel > 0:
             bpy.ops.object.hook_add_selob()
-        bpy.ops.mesh.select_all(action = 'DESELECT')
+        bpy.ops.mesh.select_all(action='DESELECT')
         bpy.ops.pc_object.toggle_edit_mode(obj_name=obj_mesh.name)
 
-def apply_hook_modifiers(context,obj):
+
+def apply_hook_modifiers(context, obj):
     """ This function applies all of the hook modifers on an object
     """
     obj.hide_set(False)
@@ -97,6 +104,7 @@ def apply_hook_modifiers(context,obj):
     for mod in obj.modifiers:
         if mod.type == 'HOOK':
             bpy.ops.object.modifier_apply(modifier=mod.name)
+
 
 def delete_obj_list(obj_list):
     ''' 
@@ -107,24 +115,25 @@ def delete_obj_list(obj_list):
         if obj.animation_data:
             for driver in obj.animation_data.drivers:
                 # THESE DRIVERS MUST BE REMOVED TO DELETE OBJECTS
-                if driver.data_path in {'hide','hide_select'}: 
-                    obj.driver_remove(driver.data_path) 
-        
+                if driver.data_path in {'hide', 'hide_select'}:
+                    obj.driver_remove(driver.data_path)
+
         obj.parent = None
         obj.hide_select = False
         obj.hide_viewport = False
         obj.select_set(True)
-        
-        #TODO: FIGURE OUT IF THIS IS RIGHT
+
+        # TODO: FIGURE OUT IF THIS IS RIGHT
         if obj.name in bpy.context.view_layer.active_layer_collection.collection.objects:
             bpy.context.view_layer.active_layer_collection.collection.objects.unlink(obj)
             # bpy.context.scene.objects.unlink(obj)
 
     for obj in obj_list:
-        bpy.data.objects.remove(obj,do_unlink=True)
+        bpy.data.objects.remove(obj, do_unlink=True)
+
 
 def select_obj_list(obj_list):
-    ''' 
+    '''
     This function selects every object in the list
     '''
     for obj in obj_list:
@@ -132,6 +141,7 @@ def select_obj_list(obj_list):
             obj.hide_select = False
             obj.hide_viewport = False
             obj.select_set(True)
+
 
 def delete_object_and_children(obj_bp):
     '''
@@ -149,6 +159,7 @@ def delete_object_and_children(obj_bp):
             obj_list.append(child)
     delete_obj_list(obj_list)
 
+
 def select_object_and_children(obj_bp):
     '''
     Selects an object and all it's children
@@ -165,8 +176,8 @@ def select_object_and_children(obj_bp):
             obj_list.append(child)
     select_obj_list(obj_list)
 
-def create_cube_mesh(name,size):
-    
+
+def create_cube_mesh(name, size):
     verts = [(0.0, 0.0, 0.0),
              (0.0, size[1], 0.0),
              (size[0], size[1], 0.0),
@@ -183,12 +194,13 @@ def create_cube_mesh(name,size):
              (1, 5, 6, 2),
              (2, 6, 7, 3),
              (4, 0, 3, 7),
-            ]
-    
-    return create_object_from_verts_and_faces(verts,faces,name)
+             ]
 
-def create_object_from_verts_and_faces(verts,faces,name):
-    """ 
+    return create_object_from_verts_and_faces(verts, faces, name)
+
+
+def create_object_from_verts_and_faces(verts, faces, name):
+    """
         Creates an object from Verties and Faces
         arg1: Verts List of tuples [(float,float,float)]
         arg2: Faces List of ints
@@ -197,28 +209,30 @@ def create_object_from_verts_and_faces(verts,faces,name):
         RETURNS bpy.types.Object
     """
     mesh = bpy.data.meshes.new(name)
-    
+
     bm = bmesh.new()
 
     for v_co in verts:
         bm.verts.new(v_co)
-    
+
     for f_idx in faces:
         bm.verts.ensure_lookup_table()
         bm.faces.new([bm.verts[i] for i in f_idx])
-    
+
     bm.to_mesh(mesh)
-    
+
     mesh.update()
-    
+
     obj_new = bpy.data.objects.new(mesh.name, mesh)
-    
+
     return obj_new
 
-def calc_distance(point1,point2):
+
+def calc_distance(point1, point2):
     """ This gets the distance between two points (X,Y,Z)
     """
-    return math.sqrt((point1[0]-point2[0])**2 + (point1[1]-point2[1])**2 + (point1[2]-point2[2])**2) 
+    return math.sqrt((point1[0] - point2[0]) ** 2 + (point1[1] - point2[1]) ** 2 + (point1[2] - point2[2]) ** 2)
+
 
 def floor_raycast(context, mx, my):
     '''
@@ -269,7 +283,8 @@ def floor_raycast(context, mx, my):
 
     return has_hit, snapped_location, snapped_normal, snapped_rotation, face_index, object, matrix
 
-def get_selection_point(context, event, ray_max=10000.0,objects=None,floor=None,exclude_objects=[]):
+
+def get_selection_point(context, event, ray_max=10000.0, objects=None, floor=None, exclude_objects=[]):
     """Gets the point to place an object based on selection"""
     # get the context arguments
     scene = context.scene
@@ -283,21 +298,21 @@ def get_selection_point(context, event, ray_max=10000.0,objects=None,floor=None,
 
     def visible_objects_and_duplis():
         """Loop over (object, matrix) pairs (mesh only)"""
- 
+
         for obj in context.visible_objects:
-             
+
             if objects:
                 if obj in objects and obj not in exclude_objects:
                     yield (obj, obj.matrix_world.copy())
-             
+
             else:
                 if obj not in exclude_objects:
                     if floor is not None and obj == floor:
                         yield (obj, obj.matrix_world.copy())
-                         
+
                     if obj.type == 'MESH' and obj.hide_select == False:
                         yield (obj, obj.matrix_world.copy())
-    
+
     def obj_ray_cast(obj, matrix):
         """Wrapper for ray casting that moves the ray into object space"""
         try:
@@ -306,7 +321,7 @@ def get_selection_point(context, event, ray_max=10000.0,objects=None,floor=None,
             ray_origin_obj = matrix_inv @ ray_origin
             ray_target_obj = matrix_inv @ ray_target
             ray_direction_obj = ray_target_obj - ray_origin_obj
-     
+
             # cast the ray
             success, location, normal, face_index = obj.ray_cast(ray_origin_obj, ray_direction_obj)
             if success:
@@ -314,16 +329,18 @@ def get_selection_point(context, event, ray_max=10000.0,objects=None,floor=None,
             else:
                 return None, None, None
         except:
-            print("ERROR IN obj_ray_cast",obj)
+            print("ERROR IN obj_ray_cast", obj)
             return None, None, None
-             
+
     best_length_squared = ray_max * ray_max
     best_obj = None
     best_hit = (0,0,0)
+    best_norm = Vector((0, 0, 0))
+
     for obj, matrix in visible_objects_and_duplis():
         if obj.type == 'MESH':
             if obj.data:
-                
+
                 hit, normal, face_index = obj_ray_cast(obj, matrix)
                 if hit is not None:
                     hit_world = matrix @ hit
@@ -332,8 +349,9 @@ def get_selection_point(context, event, ray_max=10000.0,objects=None,floor=None,
                         best_hit = hit_world
                         best_length_squared = length_squared
                         best_obj = obj
-                        
-    return best_hit, best_obj
+                        best_norm = normal
+
+    return best_hit, best_obj, best_norm
 
 def get_drivers(obj):
     """ This gets all the drivers on an object
@@ -347,11 +365,12 @@ def get_drivers(obj):
         for driver in obj.data.animation_data.drivers:
             drivers.append(driver)
 
-    return drivers        
+    return drivers
 
-def update_file_browser_path(context,path):
+
+def update_file_browser_path(context, path):
     """ This updates the filebrowser path
-    """    
+    """
     for area in context.screen.areas:
         if area.type == 'FILE_BROWSER':
             for space in area.spaces:
@@ -368,11 +387,12 @@ def update_file_browser_path(context,path):
                         params.use_filter_font = False
                         params.use_filter_folder = False
                         params.use_filter_blender = False
-                        params.use_filter_image = True  
+                        params.use_filter_image = True
 
-def register_library(name,activate_id,drop_id,icon):
+
+def register_library(name, activate_id, drop_id, icon):
     """ This registers a library with PyClone
-    """    
+    """
     pyclone = get_wm_props(bpy.context.window_manager)
     if name not in pyclone.libraries:
         pyclone.add_library(name=name,
@@ -380,8 +400,9 @@ def register_library(name,activate_id,drop_id,icon):
                             drop_id=drop_id,
                             icon=icon)
 
+
 def unregister_library(name):
     """ This unregisters a library with PyClone
-    """    
+    """
     pyclone = get_wm_props(bpy.context.window_manager)
     pyclone.remove_library(name)

--- a/walls/wall_ops.py
+++ b/walls/wall_ops.py
@@ -117,7 +117,7 @@ class home_builder_OT_draw_multiple_walls(bpy.types.Operator):
         self.mouse_x = event.mouse_x
         self.mouse_y = event.mouse_y
 
-        selected_point, selected_obj = pc_utils.get_selection_point(context,event,exclude_objects=self.exclude_objects)
+        selected_point, selected_obj, selected_normal = pc_utils.get_selection_point(context,event,exclude_objects=self.exclude_objects)
 
         self.position_object(selected_point,selected_obj)
         self.set_end_angles()            


### PR DESCRIPTION
I've added quickfire placement as well, looping out of finish() which terminates on cancel event, a parent rotation accumulator to handle parents without applied rotations. For standard placement (no wall or selected_cabinet) I've got it picking up the floor rotation so can get ortho placement in realworld settings (orientation not aligned to xy), maybe an align to custom transform orientations could be an option instead?

One last thing I'm gonna have a look at is picking up backside of cabinets to auto rotate back on themselves for island benches to avoid manual rotation settings. On the topic my install isn't catching arrow events for rotations.

Cursor is setting base elevation